### PR TITLE
Update the Broadmoor sim link to open the edits

### DIFF
--- a/book/src/proposals/broadmoor.md
+++ b/book/src/proposals/broadmoor.md
@@ -521,7 +521,7 @@ safer, and more pleasant trips without unduly impacting other traffic.
 
 If you'd like to see for yourself what the Broadmoor proposal looks like, give
 it a try, [you can run A/B Street in your
-browser](http://abstreet.s3-website.us-east-2.amazonaws.com/0.2.48/abstreet.html?--dev&system/us/seattle/scenarios/arboretum/weekday.bin)
+browser](http://abstreet.s3-website.us-east-2.amazonaws.com/0.2.49/abstreet.html?--dev&system/us/seattle/scenarios/arboretum/weekday.bin&--edits=broadmoor%20access)
 or [download the desktop
 client](https://a-b-street.github.io/docs/user/index.html).
 


### PR DESCRIPTION
I know there was talk of setting up a `/latest/` URL, but I don't really mind pinning to a particular version. The release process doesn't have any explicit tests to make sure the Broadmoor proposal continues to have sane results, so when there's a UI fix or major fix that'll impact the article, we can more deliberately choose to update it.