### PR TITLE
Add info on editing data.json

### DIFF
--- a/book/src/tech/dev/README.md
+++ b/book/src/tech/dev/README.md
@@ -56,15 +56,32 @@ One-time setup:
 
 ## Downloading more cities
 
-Most easily, you can download new cities using the UI directly.
+Most easily, you can download new cities using the GUI directly.
 
 As data formats change over time, things in the `data/` directory not under
 version control will get out of date. At any time, you can run
 `cargo run --bin updater` from the main repository directory to update only the
 files that have changed.
 
-You can also opt into downloading updates for more cities by editing
-`data/player/data.json`. If you want to opt into absolutely everything:
+You can also opt into downloading updates for more cities from the command
+line by editing `data/player/data.json`.
+If you want to add data for Leeds, GB, for example, you could edit that file
+so that it contains the following:
+
+```json
+{ 
+  "runtime": [
+    "gb/leeds",
+    "us/seattle"
+  ],
+  "input": [
+    "gb/leeds",
+    "us/seattle"
+  ]
+}
+```
+
+If you want to opt into absolutely everything:
 `cargo run --bin updater -- --opt-into-all > data/player/data.json`
 
 ## Building map data


### PR DESCRIPTION
I'm not sure that this is correct but it worked for me and is good to show an example of what the file could look like. I assume that this file is auto-updated if you opt to download data from more cities from the GUI but not sure, worth saying explicitly either way I think. Any follow-up changes to this welcome and happy to pause this if it will change more with the `cli` changes... I think there could be a helper function to add a new city e.g this totally made up example:

```
abcli add_city leeds
```

that would auto edit the file to avoid having to edit it directly and risk making a mistake in the fiddly JSON syntax.