### PR TITLE
fixing typo in team.md 

### DIFF
--- a/book/src/project/contributing.md
+++ b/book/src/project/contributing.md
@@ -23,7 +23,7 @@ real-world throughput/delay measurements.
 
 Do you sling around population and aggregated origin/destination data with R or
 Python? Great, help us generate realistic
-[travel demand models](tech/dev/formats/scenarios.md)! Work in whatever language
+[travel demand models](../tech/dev/formats/scenarios.md)! Work in whatever language
 you like best; we'll settle on a common format.
 
 ### Working on A/B Street itself

--- a/book/src/project/team.md
+++ b/book/src/project/team.md
@@ -26,9 +26,9 @@ Programming:
 - Lots of helpful PRs from [Javed Nissar](https://github.com/RestitutorOrbis)
 - Lots of traffic signal and uber-turn work from
   [Bruce](https://github.com/BruceBrown)
-- [osm2lanes](https://github.com/a-b-street/osm2lanes) by [Michael Droogleever
-- Fortuyn](https://github.com/droogmic) and [Ben
-- Ritter](https://github.com/BudgieInWA)
+- [osm2lanes](https://github.com/a-b-street/osm2lanes) by
+  [Michael Droogleever Fortuyn](https://github.com/droogmic) and
+  [Ben Ritter](https://github.com/BudgieInWA)
 
 Graphics / design:
 


### PR DESCRIPTION
Here is what the documentation looked like before the change:
<img width="628" alt="image" src="https://user-images.githubusercontent.com/89562186/213528811-f8286ace-fb84-4ab0-9f5b-33d1bc4718f2.png">

Here is what it looks like after (I am not sure if this the intended format but I made an educated guess)
<img width="619" alt="image" src="https://user-images.githubusercontent.com/89562186/213528949-8c9173f7-0e49-4163-9eb0-3c9675930247.png">


Update on second commit:
Closes #40 